### PR TITLE
context: allow to specify a context during the put (out.sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Parameters:
 
  * **`commit`** - specific commit sha affiliated with the status. Value must be either: path to an input git directory whose detached `HEAD` will be used; or path to an input file whose contents is the sha
  * **`state`** - the state of the status. Must be one of `pending`, `success`, `error`, or `failure`
+ * `context` - a label to differentiate this status from the status of other systems (default: `context value from the resource configuration`)
  * `description` - a short description of the status
  * `description_path` - path to an input file whose data is the value of `description`
  * `target_url` - the target URL to associate with the status (default: concourse build link)

--- a/bin/out
+++ b/bin/out
@@ -8,6 +8,7 @@ load_source
 eval $( jq -r '{
   "params_commit": .params.commit,
   "params_state": .params.state,
+  "params_context": ( .params.context // "'$source_context'" ),
   "params_description": ( .params.description // "" ),
   "params_description_path": ( .params.description_path // "" ),
   "params_target_url": ( .params.target_url // "$ATC_EXTERNAL_URL/builds/$BUILD_ID" )
@@ -61,7 +62,7 @@ jq -c -n \
   --arg state "$params_state" \
   --arg target_url "$target_url" \
   --arg description "$( cat $description_path )" \
-  --arg context "$source_context" \
+  --arg context "$params_context" \
   '{
     "context": $context,
     "description": $description,


### PR DESCRIPTION
This commit allow you to override context for each put.
If you don't specify context param during the put, the default one
from the resource configuration will be used.

The goal is to be able to declare one concourse resource to report status for
multiple jobs

For example :

* Job unittest : context unittest
* Job functionnal-tests: context functionnal-tests

The result of that in github will display a status for each jobs in your CI
as https://raw.githubusercontent.com/quinkennedy/travis-github-lint-status/master/example.png