### PR TITLE
add option to suppress certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A [Concourse](http://concourse.ci/) [resource](http://concourse.ci/resources.htm
  * `branch` - the branch currently being monitored (default: `master`)
  * `context` - a label to differentiate this status from the status of other systems (default: `default`)
  * `endpoint` - GitHub API endpoint (default: `https://api.github.com`)
+ * `skip_ssl_verification` - Disable certificate validation for GitHub API calls (default: `false`)
 
 
 ## Behavior

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -25,7 +25,8 @@ load_source () {
     "source_access_token": .source.access_token,
     "source_branch": ( .source.branch // "master" ),
     "source_context": ( .source.context // "default" ),
-    "source_endpoint": ( .source.endpoint // "https://api.github.com" )
+    "source_endpoint": ( .source.endpoint // "https://api.github.com" ),
+    "skip_ssl_verification": ( .source.skip_ssl_verification // "false" )
     } | to_entries[] | .key + "=" + @sh "\(.value)"
   ' < /tmp/stdin )
 }
@@ -42,5 +43,10 @@ buildtpl () {
 }
 
 curlgh () {
-  curl -s -H "Authorization: token $source_access_token" $@
+  if $skip_ssl_verification; then
+    skip_verify_arg="-k"
+  else
+    skip_verify_arg=""
+  fi
+  curl $skip_verify_arg -s -H "Authorization: token $source_access_token" $@
 }


### PR DESCRIPTION
This is relevant for "private" GitHub (enterprise) instances using self-signed certificates. An equivalent option is offered for the "official" git resource or jtarchie/pr.