### PR TITLE
add target_url_path (similar to description_path)

### DIFF
--- a/bin/out
+++ b/bin/out
@@ -10,7 +10,8 @@ eval $( jq -r '{
   "params_state": .params.state,
   "params_description": ( .params.description // "" ),
   "params_description_path": ( .params.description_path // "" ),
-  "params_target_url": ( .params.target_url // "$ATC_EXTERNAL_URL/builds/$BUILD_ID" )
+  "params_target_url": ( .params.target_url // ""),
+  "params_target_url_path": ( .params.target_url_path // "" )
 } | to_entries[] | .key + "=" + @sh "\(.value)"' < /tmp/stdin )
 
 
@@ -46,10 +47,14 @@ fi
 # target_url
 #
 
-target_url=""
+target_url_path="/tmp/target_url"
 
-if [ -n "$params_target_url" ] ; then
-  target_url=$( echo "$params_target_url" | buildtpl )
+if [[ -n "$params_target_url" ]] ; then
+  echo "$params_target_url" > "$target_url_path"
+elif [[ -n "$params_target_url_path" ]] ; then
+  cp "$params_target_url_path" "$target_url_path"
+else
+  echo "$ATC_EXTERNAL_URL/builds/$BUILD_ID" > "$target_url_path"
 fi
 
 
@@ -59,7 +64,7 @@ fi
 
 jq -c -n \
   --arg state "$params_state" \
-  --arg target_url "$target_url" \
+  --arg target_url "$( cat $target_url_path | buildtpl )" \
   --arg description "$( cat $description_path )" \
   --arg context "$source_context" \
   '{


### PR DESCRIPTION
This PR adds target_url_path parameter, similar to description_path, allowing to get target URL from file.
Expanding template variables is moved downwards, to allow to use template variables also when URL comes from file.