### PR TITLE
Auto remove trailing slash from API Endpoint

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -29,6 +29,11 @@ load_source () {
     "skip_ssl_verification": ( .source.skip_ssl_verification // "false" )
     } | to_entries[] | .key + "=" + @sh "\(.value)"
   ' < /tmp/stdin )
+  
+  if  [ "${source_endpoint: -1}" = "/" ]
+  then
+    source_endpoint="${source_endpoint:: -1}"
+  fi
 }
 
 buildtpl () {


### PR DESCRIPTION
When I first implemented this resource, I copied and pasted the API endpoint I used for the pull request resource not realizing that the trailing slash would cause the resource to fail. I simply added a check on the last character for a trailing slash, if found, it resets `source_endpoint` to itself without the slash.