### PR TITLE
Add retry parameters and stronger retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Parameters:
  * `description` - a short description of the status
  * `description_path` - path to an input file whose data is the value of `description`
  * `target_url` - the target URL to associate with the status (default: concourse build link)
-
+ * `retry_timeout` - the amount of time in seconds to wait while retrying for the status (Default: 3)
+ * `retry_count` - the number of times to retry for the status to be ready (Default: 5)
 
 ## Example
 

--- a/bin/in
+++ b/bin/in
@@ -11,6 +11,13 @@ eval $( jq -r '{
   "version_status": .version.status
 } | to_entries[] | .key + "=" + @sh "\(.value)"' < /tmp/stdin )
 
+#
+# check retry counter
+#
+
+REMAINING_TRIES="${retry_count:-5}"
+
+while true; do
 
 #
 # lookup
@@ -30,9 +37,24 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$version_commit/status
 # validate
 #
 
-jq -e '.status' < /tmp/status > /dev/null \
-  || fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
+jq -e '.status' < /tmp/status > /dev/null
+check_status="$?"
 
+if [ "$check_status" -eq 0 ]; then
+  break
+elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 1 ]; then
+  fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
+fi
+
+#
+# decrease retry counter and loop
+#
+
+REMAINING_TRIES=$(($REMAINING_TRIES - 1))
+
+sleep "${retry_timeout:-3}"
+
+done
 
 #
 # concourse

--- a/bin/out
+++ b/bin/out
@@ -91,9 +91,9 @@ jq -c -n \
 # check retry counter
 #
 
-REMAINING_TRIES=5
+REMAINING_TRIES="${retry_count:-5}"
 
-while [[ $REMAINING_TRIES -gt 0 ]]; do
+while true; do
 
 #
 # lookup
@@ -112,9 +112,14 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$source_branch/status"
 # validate
 #
 
-[[ -s /tmp/status ]] \
-  && jq -e '.status' < /tmp/status > /dev/null \
-  && break
+jq -e '.status' < /tmp/status > /dev/null
+check_status="$?"
+
+if [ "$check_status" -eq 0 ]; then
+  break
+elif [ "$check_status" -gt 0 ] && [ "$REMAINING_TRIES" -le 1 ]; then
+  fatal "Status not found on $( jq -r '.sha' < /tmp/status )"
+fi
 
 #
 # decrease retry counter and loop
@@ -122,7 +127,7 @@ curlgh "$source_endpoint/repos/$source_repository/commits/$source_branch/status"
 
 REMAINING_TRIES=$(($REMAINING_TRIES - 1))
 
-sleep 1
+sleep "${retry_timeout:-3}"
 
 done
 


### PR DESCRIPTION
This PR adds the following :
- A parameter for setting the sleep duration in the retry loop
- A parameter for setting the number of retries to the retry loop
- The retry loop is present in both `in` and `out`
- The retry loop only `fatal`s out on the final try